### PR TITLE
Image upload Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Add bundle routes
     {% endstylesheets %}
 {% endblock %}
 
+{% block javascripts %}
+  {% javascripts output='js/compiled/tinymce-image-upload.js' '@GwinnTinymceFastloadBundle/Resources/public/js/tinymce-image-upload.js' %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+  {% endjavascripts %}
+{% endblock %}
+
 ```
 
 ## Copy resources to web folder

--- a/Resources/public/js/tinymce-fastload.js
+++ b/Resources/public/js/tinymce-fastload.js
@@ -1,29 +1,6 @@
+var globalEd = undefined;
+
 function tinymce_button_image_uploader(ed) {
+    globalEd = ed;
     $('#tinymce_file_uploader input[type=file]').click();
-
-    $('#tiny_inner_image').one('change', function (event) {
-        event.stopPropagation();
-        event.preventDefault();
-
-        formElement = document.getElementById("tinymce_file_uploader");
-        data = new FormData(formElement);
-
-        $.ajax({
-            url: $('#tinymce_file_uploader').attr('action'),
-            type: 'POST',
-            data: data,
-            contentType: false,
-            processData: false,
-            success: function (response) {
-                if (typeof(tinymce) != 'undefined') {
-                    ed.selection.setContent(response);
-                }
-            },
-            error: function () {
-                alert('Whoa! Something went wrong. Try again later.');
-            }
-        });
-    });
-
-    return false;
 }

--- a/Resources/public/js/tinymce-image-upload.js
+++ b/Resources/public/js/tinymce-image-upload.js
@@ -1,0 +1,23 @@
+$('#tiny_inner_image').bind('change', function (event) {
+    formElement = document.getElementById("tinymce_file_uploader");
+    data = new FormData(formElement);
+
+    $.ajax({
+        url: $('#tinymce_file_uploader').attr('action'),
+        type: 'POST',
+        data: data,
+        contentType: false,
+        processData: false,
+        success: function (response) {
+            if (typeof(tinymce) != 'undefined') {
+                globalEd.selection.setContent(response);
+
+                // Remove uploaded image, so it is possibly to reupload the same
+                $('#tiny_inner_image').closest('form').get(0).reset();
+            }
+        },
+        error: function () {
+            alert('Bild konnte nicht erfolgreich hochgeladen werden.');
+        }
+    });
+});

--- a/Resources/views/Uploader/tinymce_file_uploader.html.twig
+++ b/Resources/views/Uploader/tinymce_file_uploader.html.twig
@@ -1,8 +1,8 @@
 <form id="tinymce_file_uploader" action="{{ path('gwinn_tinymce_fastload_uploader') }}" method="post" enctype="multipart/form-data">
-    <input type="file" id="tiny_inner_image" name="tiny_inner_image">
+  <input type="file" id="tiny_inner_image" name="tiny_inner_image">
 </form>
 
-{% javascripts output='js/compiled/script.js' '@GwinnTinymceFastloadBundle/Resources/public/js/*' %}
+{% javascripts output='js/compiled/tinymce-image-upload-callback.js' '@GwinnTinymceFastloadBundle/Resources/public/js/tinymce-fastload.js' %}
     <script type="text/javascript" src="{{ asset_url }}"></script>
 {% endjavascripts %}
 


### PR DESCRIPTION
- multiple image uploads (upload, cancel, upload, select: resulted in 2 images... etc)
- image upload in IE (Edge) was not possible
  By
- splitting up callback JS and event handling
